### PR TITLE
Add withoutresponses marker

### DIFF
--- a/pytest_responses.py
+++ b/pytest_responses.py
@@ -6,6 +6,13 @@ import responses
 
 
 # pytest plugin support
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        'withoutresponses: Tests which need access to external domains.'
+    )
+
+
 def pytest_runtest_setup(item):
     if not item.get_marker('withoutresponses'):
         responses.start()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [pytest]
-addopts=--tb=short -p no:doctest
+addopts=
+    --strict
+    --tb=short
+    -p no:doctest
 norecursedirs = bin dist docs htmlcov .* {args}
 
 [bdist_wheel]

--- a/test_pytest_responses.py
+++ b/test_pytest_responses.py
@@ -8,6 +8,8 @@ import pytest
 
 from requests.exceptions import ConnectionError
 
+pytest_plugins = str('pytester')
+
 
 @pytest.mark.withoutresponses
 def test_disabled():
@@ -22,3 +24,8 @@ def test_enabled():
         requests.get('http://responses.invalid')
 
     assert len(responses.calls) == 1
+
+
+def test_marker(testdir):
+    result = testdir.runpytest('--markers')
+    assert '@pytest.mark.withoutresponses' in result.stdout.str()


### PR DESCRIPTION
This pull request add a "withoutresponses" marker. It fixes #3.

It adds a test that verifies that the marker exists. Furthermore it adds the `--strict` option for pytest as an additional check.