### PR TITLE
Compatibility fixes for Pytest 4.0

### DIFF
--- a/pytest_responses.py
+++ b/pytest_responses.py
@@ -12,12 +12,12 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    if not item.get_marker('withoutresponses'):
+    if not item.get_closest_marker('withoutresponses'):
         responses_.start()
 
 
 def pytest_runtest_teardown(item):
-    if not item.get_marker('withoutresponses'):
+    if not item.get_closest_marker('withoutresponses'):
         try:
             responses_.stop()
             responses_.reset()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts=
     --strict
     --tb=short

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup_requires = []
 
 install_requires = [
     'responses',
-    'pytest>=2.5',
+    'pytest>=3.6',
 ]
 
 tests_require = [


### PR DESCRIPTION
This PR adds compatibility with pytest version 4.0.

Currently pytest-responses does not work with pytest 4.x with the following error raised for each test:

```
def pytest_runtest_setup(item):
>       if not item.get_marker('withoutresponses'):
E       AttributeError: 'Function' object has no attribute 'get_marker'
```

The `get_marker` function has been removed as per https://github.com/pytest-dev/pytest/issues/4546, and this PR replaces this with the `get_closest_marker` function.