### PR TITLE
Add compatibility for pytest>=4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,8 @@ matrix:
         - make
     - python: 3.6
       install:
+        - pip install pytest==3.5
+        - make
+    - python: 3.6
+      install:
         - make

--- a/pytest_responses.py
+++ b/pytest_responses.py
@@ -1,6 +1,15 @@
+from distutils.version import LooseVersion
+
 import pytest
 
 import responses as responses_
+
+
+def get_withoutresponses_marker(item):
+    if LooseVersion(pytest.__version__) >= LooseVersion('4.0.0'):
+        return item.get_closest_marker('withoutresponses')
+    else:
+        return item.get_marker('withoutresponses')
 
 
 # pytest plugin support
@@ -12,12 +21,12 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    if not item.get_marker('withoutresponses'):
+    if not get_withoutresponses_marker(item):
         responses_.start()
 
 
 def pytest_runtest_teardown(item):
-    if not item.get_marker('withoutresponses'):
+    if not get_withoutresponses_marker(item):
         try:
             responses_.stop()
             responses_.reset()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts=
     --strict
     --tb=short


### PR DESCRIPTION
@dcramer , I wanted to get https://github.com/getsentry/pytest-responses/pull/7 across the finish line. This addresses https://github.com/getsentry/pytest-responses/issues/8 and adds compatibility for pytest 4 (specifically 4.1 that removes a deprecated API)

This PR maintains backwards compatibility. I wasn't sure of the best method for comparing version numbers, so I'm happy to quickly implement any suggestions. I also updated the travis.yml to explicitly test against 3.5 with python 3.6. Let me know if there is a better version to test against in the pytest 3 series.