### PR TITLE
Fixed an error when the first test is skipped

### DIFF
--- a/pytest_responses.py
+++ b/pytest_responses.py
@@ -30,8 +30,8 @@ def pytest_runtest_teardown(item):
         try:
             responses_.stop()
             responses_.reset()
-        except RuntimeError:
-            # patcher was already uninstalled and responses doesnt let us
+        except (AttributeError, RuntimeError):
+            # patcher was already uninstalled (or not installed at all) and responses doesnt let us
             # force maintain it
             pass
 


### PR DESCRIPTION
This fixes https://github.com/getsentry/pytest-responses/issues/10