### PR TITLE
ci: fix broken workflow and modernize CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,18 @@ jobs:
         run: pip install tox
       - name: Run Tests
         run: tox -e py
+
+  # Single stable check name for branch protection rules — require 'test-results'
+  # instead of individual matrix jobs so adding/removing Python versions doesn't
+  # require updating branch protection settings.
+  test-results:
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix results
+        run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "Tests failed"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,8 @@
 name: Test
 on:
-  # Run CI on all pushes to the master and release/** branches, and on all new
-  # pull requests, and on all pushes to pull requests (even if a pull request
-  # is not against master).
   push:
     branches:
-      - "master"
+      - "main"
       - "releases/**"
   pull_request:
 defaults:
@@ -13,12 +10,17 @@ defaults:
     shell: bash
 jobs:
   test:
-    runs-on: ubuntu-18.04
-    name: "test"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+    name: "test (Python ${{ matrix.python-version }})"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install Tox
-        run:  sudo apt-get install tox
+        run: pip install tox
       - name: Run Tests
-        run:  tox
+        run: tox -e py

--- a/pytest_responses.py
+++ b/pytest_responses.py
@@ -36,7 +36,7 @@ def pytest_runtest_teardown(item):
             pass
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def responses():
     with responses_.RequestsMock() as rsps:
         yield rsps

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-# 2.5.0 is what we can get easily on Ubuntu 18.04
-minversion = 2.5.0
-envlist = py27,py39
+minversion = 4.0.0
+envlist = py39,py311,py312
 
 [testenv]
 setenv =


### PR DESCRIPTION
## What broke

GitHub Actions CI was completely non-functional due to multiple compounding issues:

1. **Wrong push trigger branch** — workflow triggers on `master` pushes, but the default branch is `main`. Branch push CI never ran.
2. **Retired runner** — `ubuntu-18.04` was removed from GitHub-hosted runners; any PR CI would immediately fail with a runner-not-found error.
3. **apt-installed tox** — `sudo apt-get install tox` gets an ancient version and is unreliable on modern runners.
4. **`pytest.yield_fixture` removed in pytest 6** — even with the above fixed, tests would fail on any modern pytest install.

## What changed

- `.github/workflows/test.yml`: switch push trigger to `main`, use `ubuntu-latest`, swap to `actions/setup-python@v5` + `pip install tox`, update `actions/checkout` to v4, add a Python 3.9/3.11/3.12 matrix
- `tox.ini`: drop EOL Python 2.7, update envlist to py39/py311/py312, bump minversion to 4.0.0
- `pytest_responses.py`: replace deprecated `@pytest.yield_fixture` with `@pytest.fixture`

The last change incorporates the fix from #29, which was approved but waiting — it's necessary for tests to pass against any modern pytest (6+).

Fixes #29.