### PR TITLE
ci: modernize build workflow for release artifacts

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,4 +7,4 @@ targets:
   - name: github
   - name: pypi
 requireNames:
-  - /^pytest_responses-.+-py2.py3-none-any.whl$/
+  - /^pytest_responses-.+-py3-none-any.whl$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
-
+          python-version: "3.11"
       - run: |
-          pip install wheel
-          python setup.py bdist_wheel
-      - uses: actions/upload-artifact@v2
+          pip install build
+          python -m build --wheel
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,3 @@ addopts=
     -p no:doctest
 norecursedirs = bin dist docs htmlcov .* {args}
 
-[bdist_wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
 setup(
     name='pytest-responses',
     version='0.5.1',
+    python_requires='>=3.9',
     author='David Cramer',
     author_email='dcramer@gmail.com',
     description=(
@@ -55,8 +56,11 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development',
         'Framework :: Pytest',
     ],


### PR DESCRIPTION
The `build.yml` release artifact workflow had two issues that would have broken the release:

- `actions/upload-artifact@v2` was retired — wheel upload would fail, Craft can't find the artifact to publish to PyPI
- `python setup.py bdist_wheel` is deprecated; switched to `python -m build --wheel`

Also updates `actions/checkout` and `actions/setup-python` to current versions.

This needs to land before triggering the v0.6.0 release.